### PR TITLE
Fix precision of share variable after collapse

### DIFF
--- a/ssaggregate.ado
+++ b/ssaggregate.ado
@@ -48,7 +48,7 @@ program def ssaggregate
 		* Deal with missing industry shares
 		use `"`sfilename'"', clear
 		collapse (sum) `s', by(`l' `t')
-		replace `s' = 1-`s'
+		replace `s' = 1-float(`s')
 
 			* If sum of shares varies, will verify S_l is controlled for
 			sum `s'


### PR DESCRIPTION
The command collapse (sum) changes the precision of shares to double instead of float. When subtracting from 1, it's generating negative values. The command `ssaggregate' generates the error message "negative weights encountered".